### PR TITLE
Adding live video monitoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -1082,9 +1082,6 @@ class live_monitor_thread(threading.Thread):
             
         while True:
             for camera in live_monitor_cameras:
-                if not 'enabled' in live_monitor_cameras[camera]:
-                    print("skip")
-
                 if not 'enabled' in live_monitor_cameras[camera] or not live_monitor_cameras[camera]['enabled']:
                     continue
 
@@ -1541,15 +1538,10 @@ def setup_live_cameras(camera_directory):
 
             live_monitor_cameras[camera]['url'] = url
             live_monitor_cameras[camera]['latest_frame'] = None
-            print(cconfig['live_monitor'])
             live_monitor_cameras[camera]['enabled'] = cconfig['live_monitor']
 
     monitor_thread = live_monitor_thread(live_image_width, live_image_height, live_fps)
     monitor_thread.start()
-
-@eel.expose
-def doprint(x):
-    print(x)
 
 @eel.expose
 def update_live_cameras():
@@ -1606,8 +1598,6 @@ def ping_cameras(camera_directory):
 
 @eel.expose
 def update_camera_frames(camera_directory):
-    print("updating camera frames")
-
     for camera in os.listdir(camera_directory):
         if os.path.isdir(os.path.join(camera_directory, camera)):
 
@@ -1693,7 +1683,6 @@ def update_camera(camera_directory, name, rtsp_url, framerate=10, resolution=256
             cconfig['crop_height'] = crop_height
             cconfig['live_monitor'] = live_monitor
 
-            print("this", live_monitor)
             live_monitor_cameras[name]['enabled'] = live_monitor
 
             # save the camera config

--- a/frontend/record.html
+++ b/frontend/record.html
@@ -314,11 +314,14 @@
                     console.log('pinging cameras...')
                 })
 
+                eel.setup_live_cameras(read('cameras'))().then( function(data) {
+                    console.log('setting up live camera streams...')
+                })
+
                 let cover = document.getElementById('cover-spin')
                 cover.style.visibility = 'visible'
 
                 setTimeout(function (){
-                    eel.update_camera_frames(read('cameras'))()
                     cover.style.visibility = 'hidden'
                 }, 5000);
 
@@ -337,10 +340,8 @@
                 cover.style.visibility = 'visible'
 
                 setTimeout(function (){
-                    eel.update_camera_frames(read('cameras'))()
                     cover.style.visibility = 'hidden'
                 }, 5000);
-
             }
 
             function drawImageScaled(img, ctx, sx, sy, sw, sh, resolution) {
@@ -581,8 +582,8 @@
             }
 
             setInterval(function (){
-                eel.update_camera_frames(read('cameras'))
-            }, 1000)
+                eel.update_live_cameras();
+            }, 1000 / 10)
 
             window.setInterval(function (){
                 eel.get_progress_update()

--- a/frontend/record.html
+++ b/frontend/record.html
@@ -130,6 +130,10 @@
                                 <p>Crop Height: </p>
                                 <input type="number" class="form-control" id="cs-crop-height" aria-describedby="directory" placeholder="1" step=".01" min="0" max="1">
                             </div>
+                            <div class="col">
+                                <p>Live Monitor: </p>
+                                <input type="checkbox" id="cs-live-monitor" aria-describedby="directory">
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -356,6 +360,7 @@
             }
 
             function cameraSettings(camera_name) {
+                eel.doprint("aksjdlakj")
                 var canvas = document.getElementById("camera-image");
                 var ctx = canvas.getContext("2d");
 
@@ -370,6 +375,11 @@
                         cy = res['crop_top_y']
                         cw = res['crop_width']
                         ch = res['crop_height']
+                        if (!('live_monitor' in res)) {
+                            live_monitor = true // Default setting for old projects without the setting
+                        } else {
+                            live_monitor = res['live_monitor']
+                        }
 
                         document.getElementById('cs-name').value = name
                         document.getElementById('cs-url').value = url
@@ -379,6 +389,7 @@
                         document.getElementById('cs-cropy').value = cy
                         document.getElementById('cs-crop-width').value = cw
                         document.getElementById('cs-crop-height').value = ch
+                        document.getElementById('cs-live-monitor').checked = live_monitor
 
                         document.getElementById('cs-resolution').onchange = drawBounds
 
@@ -386,7 +397,6 @@
                         document.getElementById('cs-cropy').onchange = drawBounds
                         document.getElementById('cs-crop-width').onchange = drawBounds
                         document.getElementById('cs-crop-height').onchange = drawBounds
-
 
                         var image = new Image();
                         image.src = document.getElementById('camera-'+camera_name).src
@@ -434,8 +444,9 @@
                 cy = document.getElementById('cs-cropy').value
                 cw = document.getElementById('cs-crop-width').value
                 ch = document.getElementById('cs-crop-height').value
+                live_monitor = document.getElementById('cs-live-monitor').checked
 
-                eel.update_camera(read('cameras'), name, url, framerate, resolution, cx, cy, cw, ch)
+                eel.update_camera(read('cameras'), name, url, framerate, resolution, cx, cy, cw, ch, live_monitor)
 
                 load_cameras()
             }
@@ -583,7 +594,7 @@
 
             setInterval(function (){
                 eel.update_live_cameras();
-            }, 1000 / 10)
+            }, 1000 / 20)
 
             window.setInterval(function (){
                 eel.get_progress_update()

--- a/frontend/record.html
+++ b/frontend/record.html
@@ -360,7 +360,6 @@
             }
 
             function cameraSettings(camera_name) {
-                eel.doprint("aksjdlakj")
                 var canvas = document.getElementById("camera-image");
                 var ctx = canvas.getContext("2d");
 


### PR DESCRIPTION
This PR adds a live monitoring option to cameras in the Record tab of CBAS.  It creates a new thread in the Python backend that maintains a list of FFMPEG processes for each camera.  These processes stream images from RTSP into Python.  The Electron frontend now queries the backend for a frame regularly and updates the HTML with the image. 

A boolean 'live_monitor' field is also added to each camera's config that is used to enable or disable live monitoring.  This is controlled by a new checkbox in the cameraSettings modal popup.